### PR TITLE
CORE-2711: add support for TGW peering routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ module "vpc" {
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.4 |
+| <a name="provider_aws.accepter"></a> [aws.accepter](#provider\_aws.accepter) | >= 4.4 |
 
 ## Modules
 
@@ -88,10 +89,10 @@ No modules.
 | [aws_ec2_tag.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_tag) | resource |
 | [aws_ec2_transit_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway) | resource |
 | [aws_ec2_transit_gateway_peering_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_peering_attachment) | resource |
+| [aws_ec2_transit_gateway_peering_attachment_accepter.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_peering_attachment_accepter) | resource |
 | [aws_ec2_transit_gateway_route.peering](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) | resource |
 | [aws_ec2_transit_gateway_route.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route) | resource |
 | [aws_ec2_transit_gateway_route_table.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table) | resource |
-| [aws_ec2_transit_gateway_route_table_association.tgw_association](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_association) | resource |
 | [aws_ec2_transit_gateway_route_table_association.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_association) | resource |
 | [aws_ec2_transit_gateway_route_table_propagation.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_route_table_propagation) | resource |
 | [aws_ec2_transit_gateway_vpc_attachment.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ec2_transit_gateway_vpc_attachment) | resource |
@@ -105,6 +106,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_accepter_region"></a> [accepter\_region](#input\_accepter\_region) | The region of the accepter VPC of the TGW Peering | `string` | `"eu-central-1"` | no |
 | <a name="input_amazon_side_asn"></a> [amazon\_side\_asn](#input\_amazon\_side\_asn) | The Autonomous System Number (ASN) for the Amazon side of the gateway. By default the TGW is created with the current default Amazon ASN. | `string` | `null` | no |
 | <a name="input_create_tgw"></a> [create\_tgw](#input\_create\_tgw) | Controls if TGW should be created (it affects almost all resources) | `bool` | `true` | no |
 | <a name="input_description"></a> [description](#input\_description) | Description of the EC2 Transit Gateway | `string` | `null` | no |
@@ -157,7 +159,6 @@ No modules.
 | <a name="output_ec2_transit_gateway_vpc_attachment_ids"></a> [ec2\_transit\_gateway\_vpc\_attachment\_ids](#output\_ec2\_transit\_gateway\_vpc\_attachment\_ids) | List of EC2 Transit Gateway VPC Attachment identifiers |
 | <a name="output_ram_principal_association_id"></a> [ram\_principal\_association\_id](#output\_ram\_principal\_association\_id) | The Amazon Resource Name (ARN) of the Resource Share and the principal, separated by a comma |
 | <a name="output_ram_resource_share_id"></a> [ram\_resource\_share\_id](#output\_ram\_resource\_share\_id) | The Amazon Resource Name (ARN) of the resource share |
-| <a name="output_tgw_association"></a> [tgw\_association](#output\_tgw\_association) | Transit Gateway Route Table Association |
 | <a name="output_tgw_peering_attachments"></a> [tgw\_peering\_attachments](#output\_tgw\_peering\_attachments) | The transit gateway peering attachments. |
 | <a name="output_tgw_peering_routes"></a> [tgw\_peering\_routes](#output\_tgw\_peering\_routes) | The transit gateway peering routes. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ module "vpc" {
 }
 ```
 
+## Peering Routes Module
+
+This module is used to manage peering routes.
+Usage
+```hcl
+module "peering_routes" {
+  source = "../modules/peering-routes"
+
+  tgw_id = "your_tgw_id"
+  cidr_blocks = ["your_cidr_blocks"]
+  tgw_peering_tag_name_value = "your_tgw_peering_tag_name_value"
+}
+```
+
+Additional info can be found in the [README.md](modules/peering-routes/README.md) file.
+
+
 ## Examples
 
 - [Complete example](https://github.com/terraform-aws-modules/terraform-aws-transit-gateway/tree/master/examples/complete) shows TGW in combination with the [VPC module](https://github.com/terraform-aws-modules/terraform-aws-vpc) and [Resource Access Manager (RAM)](https://aws.amazon.com/ram/).

--- a/main.tf
+++ b/main.tf
@@ -207,7 +207,7 @@ resource "aws_ec2_transit_gateway_peering_attachment" "this" {
 
   tags = merge(
     local.tags,
-    { Name = "peering-${each.value.peer_region}" }
+    { Name = replace("peering-${each.key}-${each.value.peer_region}","_","-") }
   )
 
   lifecycle {
@@ -224,7 +224,7 @@ resource "aws_ec2_transit_gateway_peering_attachment_accepter" "this" {
 
   tags = merge(
     local.tags,
-    { Name = "peering-accepter-${each.value.peer_region}" }
+    { Name = replace("peering-accepter-${each.key}-${each.value.peer_region}","_","-") }
   )
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -231,6 +231,7 @@ resource "aws_ec2_transit_gateway_peering_attachment_accepter" "this" {
     create_before_destroy = true
   }
 }
+
 # Transit Gateway Route Table
 resource "aws_ec2_transit_gateway_route" "peering" {
   for_each = local.tgw_peering_route_table_routes
@@ -241,11 +242,3 @@ resource "aws_ec2_transit_gateway_route" "peering" {
 
   depends_on = [aws_ec2_transit_gateway_peering_attachment_accepter.this]
 }
-
-# Transit Gateway Route Table Association
-# resource "aws_ec2_transit_gateway_route_table_association" "tgw_association" {
-#   for_each = local.tgw_peering_attachments_associations
-
-#   transit_gateway_attachment_id  = each.value.id
-#   transit_gateway_route_table_id = var.tgw_association_default_route_table_id
-# }

--- a/main.tf
+++ b/main.tf
@@ -207,7 +207,7 @@ resource "aws_ec2_transit_gateway_peering_attachment" "this" {
 
   tags = merge(
     local.tags,
-    { Name = replace("peering-${each.key}-${each.value.peer_region}","_","-") }
+    { Name = replace("peering-${each.key}-${each.value.peer_region}", "_", "-") }
   )
 
   lifecycle {
@@ -224,7 +224,7 @@ resource "aws_ec2_transit_gateway_peering_attachment_accepter" "this" {
 
   tags = merge(
     local.tags,
-    { Name = replace("peering-accepter-${each.key}-${each.value.peer_region}","_","-") }
+    { Name = replace("peering-accepter-${each.key}-${each.value.peer_region}", "_", "-") }
   )
 
   lifecycle {

--- a/modules/peering-routes/README.md
+++ b/modules/peering-routes/README.md
@@ -1,0 +1,32 @@
+ # Peering Routes Module
+
+ This module is used to manage peering routes.
+
+ ## Usage
+
+ ```hcl
+ module "peering_routes" {
+  source = "../modules/peering-routes"
+
+  tgw_id = "your_tgw_id"
+  cidr_blocks = ["your_cidr_blocks"]
+  tgw_peering_tag_name_value = "your_tgw_peering_tag_name_value"
+}
+ ```
+
+## Inputs
+
+| Name                         | Description                                                                           |      Type      | Default | Required |
+| ---------------------------- | ------------------------------------------------------------------------------------- | :------------: | :-----: | :------: |
+| `source`                     | The source of the module                                                              |    `string`    |   n/a   |   yes    |
+| `tgw_id`                     | The ID of the transit gateway                                                         |    `string`    |   n/a   |   yes    |
+| `cidr_blocks`                | A list of CIDR blocks to route                                                        | `list(string)` |   n/a   |   yes    |
+| `tgw_peering_tag_name_value` | The value of the Name tag used as a filter for the Transit Gateway Peering Attachment |    `string`    |   n/a   |   yes    |
+
+## Outputs
+
+| Name                          | Description                                 |
+| ----------------------------- | ------------------------------------------- |
+| `route_table_id`              | The ID of the route table                   |
+| `route_ids`                   | The IDs of the TGW routes                   |
+| `route_table_association_ids` | The IDs of the TGW route table associations |

--- a/modules/peering-routes/main.tf
+++ b/modules/peering-routes/main.tf
@@ -1,0 +1,40 @@
+# Get the attachment ID for the transit gateway
+data "aws_ec2_transit_gateway_attachment" "attachment" {
+  filter {
+    name   = "transit-gateway-id"
+    values = [var.tgw_id]
+  }
+
+  filter {
+    name   = "resource-type"
+    values = ["peering"]
+  }
+
+  # Tag
+  filter {
+    name   = "tag:Name"
+    values = [var.tgw_peering_tag_name_value]
+  }
+}
+
+# Get the route table ID for the transit gateway
+data "aws_ec2_transit_gateway_route_table" "route_table" {
+  filter {
+    name   = "transit-gateway-id"
+    values = [var.tgw_id]
+  }
+
+  filter {
+    name   = "default-association-route-table"
+    values = ["true"]
+  }
+}
+
+# Add routes to the specified Transit Gateway Route Table
+resource "aws_ec2_transit_gateway_route" "this" {
+  for_each = toset(var.cidr_blocks)
+
+  destination_cidr_block         = each.value
+  transit_gateway_route_table_id = data.aws_ec2_transit_gateway_route_table.route_table.id
+  transit_gateway_attachment_id  = data.aws_ec2_transit_gateway_attachment.attachment.id
+}

--- a/modules/peering-routes/outputs.tf
+++ b/modules/peering-routes/outputs.tf
@@ -1,0 +1,14 @@
+output "route_table_id" {
+  description = "The ID of the route table"
+  value       = data.aws_ec2_transit_gateway_route_table.route_table.id
+}
+
+output "route_ids" {
+  description = "The IDs of the TGW routes"
+  value       = [for r in aws_ec2_transit_gateway_route.this : r.id]
+}
+
+output "route_table_association_ids" {
+  description = "The IDs of the TGW route table associations"
+  value       = [for r in aws_ec2_transit_gateway_route.this : r.transit_gateway_attachment_id]
+}

--- a/modules/peering-routes/variables.tf
+++ b/modules/peering-routes/variables.tf
@@ -1,0 +1,15 @@
+# Variables for the module
+variable "tgw_id" {
+  description = "The ID of the transit gateway"
+  type        = string
+}
+
+variable "cidr_blocks" {
+  description = "A list of CIDR blocks to route"
+  type        = list(string)
+}
+
+variable "tgw_peering_tag_name_value" {
+  description = "The value of the Name tag for the Transit Gateway Peering Attachment"
+  type        = string
+}

--- a/modules/peering-routes/versions.tf
+++ b/modules/peering-routes/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.4"
+    }
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -123,10 +123,10 @@ output "tgw_peering_routes" {
   description = "The transit gateway peering routes."
 }
 
-output "tgw_association" {
-  description = "Transit Gateway Route Table Association"
-  value = { for k, v in aws_ec2_transit_gateway_route_table_association.tgw_association : k => {
-    transit_gateway_attachment_id  = v.transit_gateway_attachment_id
-    transit_gateway_route_table_id = v.transit_gateway_route_table_id
-  } }
-}
+# output "tgw_association" {
+#   description = "Transit Gateway Route Table Association"
+#   value = { for k, v in aws_ec2_transit_gateway_route_table_association.tgw_association : k => {
+#     transit_gateway_attachment_id  = v.transit_gateway_attachment_id
+#     transit_gateway_route_table_id = v.transit_gateway_route_table_id
+#   } }
+# }

--- a/outputs.tf
+++ b/outputs.tf
@@ -122,11 +122,3 @@ output "tgw_peering_routes" {
   } }
   description = "The transit gateway peering routes."
 }
-
-# output "tgw_association" {
-#   description = "Transit Gateway Route Table Association"
-#   value = { for k, v in aws_ec2_transit_gateway_route_table_association.tgw_association : k => {
-#     transit_gateway_attachment_id  = v.transit_gateway_attachment_id
-#     transit_gateway_route_table_id = v.transit_gateway_route_table_id
-#   } }
-# }

--- a/variables.tf
+++ b/variables.tf
@@ -27,12 +27,6 @@ variable "tgw_association_default_route_table_id" {
   default     = "tgw-rtb-0e2771324a8b5ccbc"
 }
 
-variable "extra_peering_routes_cidr_blocks" {
-  description = "A list of CIDR blocks to route"
-  type        = list(string)
-  default     = []
-}
-
 variable "tgw_peering_attachments" {
   description = "A map of transit gateway peering attachments"
   type = map(object({

--- a/variables.tf
+++ b/variables.tf
@@ -136,6 +136,12 @@ variable "tgw_default_route_table_tags" {
   default     = {}
 }
 
+variable "accepter_region" {
+  description = "The region of the accepter VPC of the TGW Peering"
+  type        = string
+  default     = "eu-central-1"
+}
+
 ################################################################################
 # VPC Attachment
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,11 @@ variable "tgw_association_default_route_table_id" {
   default     = "tgw-rtb-0e2771324a8b5ccbc"
 }
 
+variable "extra_peering_routes_cidr_blocks" {
+  description = "A list of CIDR blocks to route"
+  type        = list(string)
+  default     = []
+}
 
 variable "tgw_peering_attachments" {
   description = "A map of transit gateway peering attachments"


### PR DESCRIPTION
## GitHub PR Summary

### Title: Enhancements to Peering Routes and AWS Provider Updates

### Summary:
- **New Peering Routes Module:** Added a module for managing Transit Gateway (TGW) peering routes.
- **AWS Provider Update:** Introduced a new provider alias `aws.accepter` for specific regional configurations.
- **Updated docs**
- **Resource Adjustments:** 
  - Included resources for accepting TGW peering attachments.
  - Updated TGW peering attachment resources with lifecycle rules and modified tags.
  - Removed the TGW route table association resource.
- **Refinements:**
  - Updated documentation and outputs to align with the new module and resource changes.
  - General code refactoring for improved readability and maintenance.
